### PR TITLE
pkgs/service-overview: sort by status & add status external

### DIFF
--- a/pkgs/service-overview/default.nix
+++ b/pkgs/service-overview/default.nix
@@ -14,11 +14,18 @@ let
 
   entry = name: val: import templates/entry.nix ({ inherit lib name; } // val);
 
+  order = [
+    "production"
+    "beta"
+    "alpha"
+    "deprecated"
+    "obsolete"
+  ];
+
   generateEntries = srvAttrs: lib.concatStrings (
-    lib.mapAttrsToList (n: v: (
-      entry n v
-    ))
-    srvAttrs);
+    lib.flatten (map (stat: lib.mapAttrsToList (n: v: (
+      if v.status == stat then entry n v else ""
+    )) srvAttrs) order));
 
   genHtml = services: minifyHTML ''
     ${header}

--- a/pkgs/service-overview/default.nix
+++ b/pkgs/service-overview/default.nix
@@ -16,6 +16,7 @@ let
 
   order = [
     "production"
+    "external"
     "beta"
     "alpha"
     "deprecated"

--- a/pkgs/service-overview/templates/entry.nix
+++ b/pkgs/service-overview/templates/entry.nix
@@ -12,6 +12,7 @@ let
     "production"     = "success";
     "deprecated"     = "error";
     "obsolete"       = "error";
+    "external"       = "primary";
     ""               = "";
   }.${s};
 


### PR DESCRIPTION
- services are now sorted by status
- adds the status `external` for SaaS and similar