### PR TITLE
modules/base: disallow unfree

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -57,11 +57,6 @@ with lib;
       mtr.enable = true;
     };
 
-    # sigh :/
-    nixpkgs.config = {
-      allowUnfree = true;
-    };
-
     environment = {
       variables.EDITOR = "vim";
       systemPackages = with pkgs; [


### PR DESCRIPTION
This can and should be done per host, remove this legacy.

Please merge, don't rebase, as referenced by hash.