### PR TITLE
monitoring: ignore nsfs mounts in alerting rules

### DIFF
--- a/modules/monitoring/alert-rules.nix
+++ b/modules/monitoring/alert-rules.nix
@@ -2,7 +2,7 @@
 with lib;
 
 let
-  deviceFilter = ''device!="ramfs",device!="rpc_pipefs",device!="lxcfs"'';
+  deviceFilter = ''device!="ramfs",device!="rpc_pipefs",device!="lxcfs",device!="nsfs"'';
 in mapAttrsToList (name: opts: {
   alert = name;
   expr = opts.condition;


### PR DESCRIPTION
Triggers false alerts when using docker.