### PR TITLE
modules/service-overview: add empty default set

### DIFF
--- a/modules/service-overview.nix
+++ b/modules/service-overview.nix
@@ -26,6 +26,7 @@ in
         '';
       };
       services = mkOption {
+        default = {};
         type = types.attrsOf (types.submodule {
           options = {
             address = mkOption {


### PR DESCRIPTION
This way, nodes with no explicit services running need not contain a
line of `mayflower.serviceOverview.services = {};`.