### PR TITLE
oxidized: add patch to exclude tplink timestamp

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -16,4 +16,16 @@ self: super:
   dovecot = super.dovecot.override { withPgSQL = true; };
   postfix = super.postfix.override { withPgSQL = true; };
   freeradius = super.freeradius.override { withJson = true; withRest = true; };
+
+  defaultGemConfig = super.defaultGemConfig // {
+    oxidized = (attrs: rec {
+      tplinkPatch = (super.fetchpatch {
+        url = https://patch-diff.githubusercontent.com/raw/ytti/oxidized/pull/1443.diff;
+        sha256 = "09dyf1hnxgdxfkh9l6y63qmm1ds5wgb2d52vvrwwc0s4gl0b1yad";
+      });
+      postInstall = ''
+        patch -p1 -d $(cat $out/nix-support/gem-meta/install-path) -i ${tplinkPatch}
+      '';
+    });
+  };
 }


### PR DESCRIPTION
This adds a patch to oxidized so that the current system time stamp is excluded from tp-link configs.