### PR TITLE
monitoring: actually enable textfile collector

### DIFF
--- a/modules/monitoring/default.nix
+++ b/modules/monitoring/default.nix
@@ -277,6 +277,7 @@ in {
             "softnet"
             "stat"
             "systemd"
+            "textfile"
             "textfile.directory /run/prometheus-node-exporter"
             "thermal_zone"
             "time"


### PR DESCRIPTION
In node_exporter 1.x, it seems the collector is no longer enabled by only specifying the directory.