### PR TITLE
modules/simplesamlphp: misc improvements

### DIFF
--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -15,7 +15,7 @@ let
   saml20-idp-hosted = pkgs.writeText "saml20-idp-hosted.php" (''
     <?php
   '' + (optionalString cfg.saml20.idp.hosted.enable ''
-    $metadata['__DYNAMIC:1__'] = array_merge([
+    $metadata['__DYNAMIC:1__'] = array_replace_recursive([
       'host' => '__DEFAULT__',
       'privatekey' => '${cfg.saml20.idp.hosted.privKeyFile}',
       'certificate' => '${cfg.saml20.idp.hosted.certificateFile}',
@@ -45,7 +45,7 @@ let
     $adminpassword = trim(file_get_contents('${cfg.adminPasswordFile}'));
     $secretsalt = trim(file_get_contents('${cfg.secretSaltFile}'));
 
-    $config = array_merge([
+    $config = array_replace_recursive([
         'baseurlpath' => '${cfg.baseUrlPath}',
         'certdir' => 'cert/',
         'loggingdir' => 'log/',
@@ -327,12 +327,12 @@ in
         type = types.str;
         default = "";
         example = ''
-	      'privacyidea' => [
-	        'privacyidea:privacyidea',
-	        'privacyideaserver' => 'https://privacyidea.example.org/',
-	        'sslverifyhost' => True,
-	        'sslverifypeer' => True,
-	        'realm' => "",
+          'privacyidea' => [
+            'privacyidea:privacyidea',
+            'privacyideaserver' => 'https://privacyidea.example.org/',
+            'sslverifyhost' => True,
+            'sslverifypeer' => True,
+            'realm' => "",
             'attributemap' => [
               'username' => 'samlLoginName',
               'surname' => 'surName',

--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -272,13 +272,11 @@ in
 
       phpSessionCookieName = mkOption {
         type = types.str;
-        default = "";
         description = "Name of php session cookie.";
       };
 
       authTokenCookieName = mkOption {
         type = types.str;
-        default = "";
         description = "Name of auth token cookie.";
       };
 

--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -69,8 +69,8 @@ let
         ),
         'showerrors' => true,
         'errorreporting' => true,
-        'logging.level' => SimpleSAML\Logger::NOTICE,
-        'logging.handler' => 'errorlog',
+        'logging.level' => ${cfg.loglevel},
+        'logging.handler' => '${cfg.logFacility}',
         'logging.facility' => defined('LOG_LOCAL5') ? constant('LOG_LOCAL5') : LOG_USER,
         'logging.processname' => 'simplesamlphp',
         'logging.logfile' => 'simplesamlphp.log',
@@ -278,6 +278,32 @@ in
       authTokenCookieName = mkOption {
         type = types.str;
         description = "Name of auth token cookie.";
+      };
+
+      loglevel = mkOption {
+        default = "info";
+        type = types.enum [ "emerg" "alert" "crit" "err" "warning" "notice" "info" "debug" ];
+        apply = x: "SimpleSAML\\Logger::${toUpper x}";
+        description = ''
+          Define the minimum log level to log. Available levels:
+          <itemizedlist>
+          <listitem><para><literal>emerg</literal></para></listitem>
+          <listitem><para><literal>alert</literal></para></listitem>
+          <listitem><para><literal>err</literal>     No statistics, only errors</para></listitem>
+          <listitem><para><literal>warning</literal> No statistics, only warnings/errors</para></listitem>
+          <listitem><para><literal>notice</literal>  Statistics and errors</para></listitem>
+          <listitem><para><literal>info</literal>    Verbose logs</para></listitem>
+          <listitem><para><literal>debug</literal>   Full debug logs - not recommended for production</para></listitem>
+          </itemizedlist>
+        '';
+      };
+
+      logFacility = mkOption {
+        default = "syslog";
+        type = types.enum [ "syslog" "file" "errorlog" "stderr" ];
+        description = ''
+          Where to write logs.
+        '';
       };
 
       extraConfig = mkOption {


### PR DESCRIPTION
Now that I'm running a setup with simplesamlphp in my personal infrastructure, I started using this fairly helpful module and decided to contribute back a few improvements.

The summaries of the commits are in the collapsible sections below:

<details>
<summary>modules/simplesamlphp: don't use an empty string as cookie default </summary>

When I initially deployed simplesamlphp to my server with leaving
`phpSessionCookieName` and `authTokenCookieName` empty (i.e. unspecified),
I got the following slightly confusing error in my logs when trying to
authenticate as `admin`:

    ERR [d5422ef7b1] Cannot set authentication token cookie: Headers already sent

The reason is actually kinda weird: SimpleSAMLPHP tries to set a cookie
using PHP's `setcookie()`-function[1]. The docs state that `false` is
returned when headers are already sent.

However this turns out to be WRONG. If the cookie name is empty and thus
an empty string is passed to `setcookie()`, `false` is returned as well.
However SimpleSAMLPHP wrongly assumes that this is due to already sent
headers and throws this bogus error message.

[1] https://www.php.net/manual/de/function.setcookie.php
</details>
<details>

<summary>modules/simplesamlphp: improve log configuration</summary>

When using the default log configuration, it has the side-effect that
all error messages are squashed into a single line and appear in a
hard-to-read format in the journal-log of `nginx.service`.

To improve the situation I bit, this patch contains the following
changes:

* Log to `syslog` by default, but make it configurable. When using the
  `syslog`-target, all logs appear line-by-line in
  `phpfpm-simplesamlphp.service`.
* Make the log-level for possible debugging efforts configurable.
</details>

<details>
<summary>modules/simplesamlphp: use `array_replace_recursive` for config merging</summary>

The current use of `array_merge` didn't provide any additional value
since

    array_merge(["foo" => "snens"], ["foo" => "topsnens"])

and

    ["foo" => "snens", "foo" => "topsnens"]

evaluate to the same value, namely

    ["foo" => "topsnens"]

I figured that using `array_replace_recursive`[1] may be the better
choice here since it's now possible to override single values in
recursive, associative arrays:

    >>> array_replace_recursive(['debug' => ['saml' => false, 'backtraces' => true]], ['debug' => ['saml' => t
    rue]])
    => [
         "debug" => [
           "saml" => true,
           "backtraces" => true,
         ],
       ]
    >>> array_merge(['debug' => ['saml' => false, 'backtraces' => true]], ['debug' => ['saml' => true]])=> [
         "debug" => [
           "saml" => true,
         ],
       ]

[1] https://www.php.net/manual/de/function.array-replace-recursive.php
</details>
