### PR TITLE
modules/simplesamlphp: fix eval for 21.05

### DIFF
--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -469,6 +469,9 @@ in
       };
     };
 
-    users.extraUsers.simplesamlphp.group = "nginx";
+    users.extraUsers.simplesamlphp = {
+      group = "nginx";
+      isSystemUser = true;
+    };
   };
 }


### PR DESCRIPTION
To quote the NixOS 21.05 "Okapi" release-notes:

> When defining a new user, one of users.users.<name>.isNormalUser and
> users.users.<name>.isSystemUser is now required

Since no default is set, this means that evaluating the
`simplesamlphp`-module on NixOS 21.05 fails with an assertion error.

This is not a breaking change since the user already has a fixed UID
allocated on existing systems, on new systems the UID will be <999 (on
my server it has `1003` for instance).