### PR TITLE
simplesamlphp: 1.17.2 -> 1.19.1

### DIFF
--- a/pkgs/simplesamlphp/default.nix
+++ b/pkgs/simplesamlphp/default.nix
@@ -3,11 +3,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "simplesamlphp-${version}";
-  version = "1.17.2";
+  version = "1.19.1";
 
   src = fetchurl {
     url = "https://github.com/simplesamlphp/simplesamlphp/releases/download/v${version}/simplesamlphp-${version}.tar.gz";
-    sha256 = "03p8q6waaiqaqr4pkj9vmq5vjgx750g5jr7v6xj9d8nbx10xcbqf";
+    sha256 = "sha256-GeOGDv9j8jZ1ebnuXCt7YJ19F9qsrNPgSCPd9ZkSR0c=";
   };
 
   buildPhase = ''


### PR DESCRIPTION
The full change-logs can be found on the vendor's homepage[1]. The
reason for the update is that there were a few minor security advisories
disclosed that affect our current version[2]. None of them seemed easily
exploitable, but since this is a rather sensitive piece of software, an
update is still a good idea.

I successfully deployed this to my own systems and tested a login via
`u2f` and `yubico-otp` for Nextcloud and `wiki-js`. No adjustment of my
existing configuration was necessary for this.

I left out an update of the module for PrivacyIDEA[3] on purpose because
I encountered some issues with `u2f`-auth then. I already filed a bug-report
for this[4].

[1] https://simplesamlphp.org/docs/stable/simplesamlphp-changelog
[2] https://simplesamlphp.org/security
[3] https://github.com/privacyidea/simplesamlphp-module-privacyidea/releases/tag/v1.9
[4] https://github.com/privacyidea/simplesamlphp-module-privacyidea/issues/108