### PR TITLE
modules/simplesamlphp: pin PHP to 7.4

### DIFF
--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -455,6 +455,7 @@ in
     services.phpfpm.pools.simplesamlphp = {
         user = "simplesamlphp";
         group = "nginx";
+        phpPackage = pkgs.php74;
         settings = {
           "listen.owner" = "nginx";
           "listen.group" = "nginx";


### PR DESCRIPTION
On NixOS 21.11 `pkgs.php` points to PHP 8.0 by default, however this
doesn't work with `simplesamlphp`.