### PR TITLE
modules/matrix: remove webclient

### DIFF
--- a/modules/matrix.nix
+++ b/modules/matrix.nix
@@ -280,7 +280,7 @@ in
           tls = false;
           x_forwarded = true;
           resources = [
-            { names = ["client" "webclient"]; compress = false; }
+            { names = ["client"]; compress = false; }
           ];
         } {
           port = 9092;


### PR DESCRIPTION
See https://matrix-org.github.io/synapse/latest/upgrade.html#dropping-support-for-webclient-listeners-and-non-https-web_client_location