### PR TITLE
modules/matrix: enable `unbind` in `ma1sd`

### DIFF
--- a/modules/matrix.nix
+++ b/modules/matrix.nix
@@ -304,6 +304,10 @@ in
           dns.overwrite.homeserver.client = [
             { name = cfg.fqdn; value = "http://127.0.0.1:8008"; }
           ];
+          session.policy.unbind = {
+            enabled = true;
+            notifications = false;
+          };
           session.policy.validation = {
             enabled = true;
             forLocal = {


### PR DESCRIPTION
Needed to properly deactivate a user. Without this being enabled, the
`deactivate`-call fails with the following error:

    Request POST http://matrix.mayflower.de/_matrix/identity/api/v1/3pid/unbind - Error M_NOT_AVAILABLE: This action is currently not available. Contact your administrator to enable it.