### PR TITLE
flake.nix: Fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,19 @@
 {
-  inputs = {};
-  outputs = {
+  description = "Mayflower-opinionated Nix modules, overlay and Hydra Configuration";
+  outputs = { ... }: {
     overlay = import ./overlay.nix;
-    nixosModules = import ./module-list.nix;
+    nixosModules = let
+      inherit (builtins) listToAttrs head match elemAt split;
+      mkModuleName = x:
+        let
+          strippedExt = baseNameOf (head (match "(.*)\\.nix$" x));
+          dirname = baseNameOf (dirOf x);
+        in "mf-${if strippedExt == "default" then dirname else strippedExt}";
+    in
+    listToAttrs
+      (map (x: {
+        name = mkModuleName (toString x);
+        value.imports = [ x ];
+      }) (import ./module-list.nix));
   };
 }


### PR DESCRIPTION
* Add a description.
* Fix evaluation (`outputs` must be a function rather than a list).
* It is a convention to expose `nixosModules` as attr-set rather than as
  list. To retain backwards-compat with e.g. our deployment, I decided
  to keep the `module-list.nix` and added a simple expression which
  generates attribute-names for modules like this:

    * `modules/simplesamlphp.nix` -> `nixosModules.mf-simplesamlphp`
    * `modules/monitoring/default.nix` -> `nixosModules.mf-monitoring`

  There's no support for deeper nesting because it simply isn't needed,
  but it should be rather trivial to implement.