### PR TITLE
modules/secrets: make secret paths available in container

### DIFF
--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -71,6 +71,10 @@ let
 
   /*
    * Given mayflower.secrets.containerSecrets, generate the containers' bind mount sets.
+   * It also generates options for `mayflower.secrets.hostSecrets` for the containers' NixOS
+   * configuration to be able to reference a secret called `service-token` with
+   * `config.mayflower.secrets.hostSecrets.service-token.path` inside the container.
+   * The path is set by the definition of `options.mayflower.secrets.hostSecrets`.
    *
    * Example:
    * genBindMounts { container-a = { service-token = {}; secret2 = {}; }; container-b = {}; }
@@ -86,6 +90,12 @@ let
    *       mountPoint = "/var/secrets/secret2";
    *     };
    *   };
+   *   container-a.config = {
+   *     mayflower.secrets.hostSecrets = {
+   *       service-token = {};
+   *       secret2 = {};
+   *     };
+   *   };
    *   container-b.bindMounts = {};
    * }
    */
@@ -98,7 +108,7 @@ let
       };
     });
     config = {
-      mayflower.secrets.hostSecrets = flip mapAttrs secretConfigs (const (const {}));
+      mayflower.secrets.hostSecrets = mapAttrs (const (const {})) secretConfigs;
     };
   });
 


### PR DESCRIPTION
Now it's possible to write

    config.mayflower.secrets.hostSecrets.foo.path

inside a NixOS container expression if the host has

    mayflower.secrets.containerSecrets.container.foo = {};

to make sure that paths aren't hardcoded anymore and it's actually
ensured that a referenced secret is actually tracked by the module.