### PR TITLE
modules/simplesamlphp: drop obsolete `rm` statement from activation script

### DIFF
--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -422,7 +422,6 @@ in
       ln -sf ${saml20-idp-hosted} /run/simplesamlphp/metadata/saml20-idp-hosted.php
       ln -sf ${authsourcesFile} /run/simplesamlphp/config/authsources.php
       ln -sf ${configFile} /run/simplesamlphp/config/config.php
-      rm /run/simplesamlphp/modules/mayflower
     '';
 
     services.nginx.enable = true;


### PR DESCRIPTION
The modules aren't created anymore, thus the `rm` fails like this:

    privacyidea-muc......> rm: cannot remove '/run/simplesamlphp/modules/mayflower': No such file or directory
    privacyidea-muc......> Activation script snippet 'simplesamlphp' failed (1)

Small oversight from 7799ded8d37b57101cf277ad3d4f69d9f58d9d6c, but with
a low impact because the rest of the activation correctly ran through
and no service was negatively impacted on the machine.