### PR TITLE
hydra-jobs: add temporary gitlab-workhorse-git-2-35-4

### DIFF
--- a/hydra-jobs/packages.nix
+++ b/hydra-jobs/packages.nix
@@ -154,6 +154,7 @@ in
   gitlab-runner = all;
   gitlab-shell = all;
   gitlab-workhorse = all;
+  gitlab-workhorse-git-2-35-4 = all; # See ../overlay.nix
   glibc = all;
   glibcLocales = all;
   gmp = all;

--- a/overlay.nix
+++ b/overlay.nix
@@ -83,4 +83,18 @@ self: super:
       })
     ];
   });
+
+  # https://github.com/NixOS/nixpkgs/blob/mf-next/nixos/modules/services/misc/gitlab.nix#L16
+  # Remove when changes from git 2.37.2 land in our nixpkgs
+  # - https://lore.kernel.org/git/xmqqedxmfyhe.fsf@gitster.g/
+  # - (commit-graph: introduce `repo_find_commit_pos_in_graph()`)
+  gitlab-workhorse-git-2-35-4 = let
+    version = "2.35.4";
+  in super.git.overrideAttrs (oldAttrs: rec {
+    inherit version;
+    src = super.fetchurl {
+      url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
+      sha256 = "sha256-mv13OdNkXggeKQkJ+47QcJ6lYmcw6Qjri1ZJ2ETCTOk=";
+    };
+  });
 }


### PR DESCRIPTION
To build the overridden git pkg introduced in upstream
gitlab-workhorse service module
https://github.com/NixOS/nixpkgs/blob/mf-next/nixos/modules/services/misc/gitlab.nix#L16

Since my system does not build this git version because of some
compound key folder names tests failing
https://public-inbox.org/git/?q=t0021+t3910 and hydra does not know
about this packaged git version, i explicitly add it here.