### PR TITLE
pytest-xdist: dontCheck on aarch64-linux

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -4,6 +4,7 @@ self: super:
   python3 = super.python3.override { packageOverrides = import ./pkgs/python-packages.nix; };
   python35 = super.python35.override { packageOverrides = import ./pkgs/python-packages.nix; };
   python36 = super.python36.override { packageOverrides = import ./pkgs/python-packages.nix; };
+  python39 = super.python39.override { packageOverrides = import ./pkgs/python-packages.nix; };
   python2 = super.python2.override { packageOverrides = import ./pkgs/python-packages.nix; };
   python = super.python.override { packageOverrides = import ./pkgs/python-packages.nix; };
 

--- a/pkgs/python-packages.nix
+++ b/pkgs/python-packages.nix
@@ -8,4 +8,8 @@ self: super: {
   rasa-nlu = self.callPackage ./python/rasa-nlu { };
   sklearn-crfsuite = self.callPackage ./python/sklearn-crfsuite { };
   # geopy FIXME
+  pytest-xdist = super.pytest-xdist.overridePythonAttrs(old: {
+    # binfmt? cpu_exec: assertion failed: (cpu == current_cpu)
+    doCheck = super.pytest-xdist.system != "aarch64-linux";
+  });
 }


### PR DESCRIPTION
meh, python3 override does not override python39Packages it seems,
and documentation for disabledTests attribute is not valid for this pkg.