### PR TITLE
modules/monitoring: allow excluding alert rules

### DIFF
--- a/modules/monitoring/alert-rules.nix
+++ b/modules/monitoring/alert-rules.nix
@@ -1,205 +1,207 @@
-{ filesystemFilter }: {
+{ filesystemFilter }: let
+  ensureComma = x: if x == "" then "" else ",${x}";
+in {
   node_deployed = {
-    condition = "node_deployed < time()-86400*14";
+    condition = excl: "node_deployed{${excl}} < time()-86400*14";
     page = false;
     summary = "{{$labels.alias}}: Last deployed on {{$labels.date}} with version {{$labels.version}}";
     description = "{{$labels.alias}}: Last deployed on {{$labels.date}} with version {{$labels.version}}";
   };
   node_down = {
-    condition = ''up{job="node"} == 0'';
+    condition = excl: ''up{job="node"${ensureComma excl}} == 0'';
     summary = "{{$labels.alias}}: Node is down.";
     description = "{{$labels.alias}} has been down for more than 2 minutes.";
   };
   node_collector_failed = {
     # FIXME remove `collector!="conntrack"` as soon as
     # https://github.com/prometheus/node_exporter/issues/2491 is resolved.
-    condition = ''node_scrape_collector_success{job="node",collector!="conntrack"} == 0'';
+    condition = excl: ''node_scrape_collector_success{job="node",collector!="conntrack"${ensureComma excl}} == 0'';
     summary = "{{$labels.alias}}: Node collector {{$labels.collector}} failed.";
     description = "{{$labels.alias}}: The collector {{$labels.collector}} of node exporter instance {{$labels.instance}} failed.";
   };
   node_systemd_service_failed = {
-    condition = ''node_systemd_unit_state{state="failed"} == 1'';
+    condition = excl: ''node_systemd_unit_state{state="failed"${ensureComma excl}} == 1'';
     summary = "{{$labels.alias}}: Service {{$labels.name}} failed to start.";
     description = "{{$labels.alias}} failed to (re)start service {{$labels.name}}.";
   };
   node_filesystem_full_80percent = {
-    condition = ''sort(node_filesystem_free_bytes{${filesystemFilter}} < node_filesystem_size_bytes{${filesystemFilter}} * 0.2) / 1024^3'';
+    condition = excl: ''sort(node_filesystem_free_bytes{${filesystemFilter}${ensureComma excl}} < node_filesystem_size_bytes{${filesystemFilter}${ensureComma excl}} * 0.2) / 1024^3'';
     time = "10m";
     summary = "{{$labels.alias}}: Filesystem is running out of space soon.";
     description = "{{$labels.alias}} device {{$labels.device}} on {{$labels.mountpoint}} got less than 20% space left on its filesystem.";
   };
   node_filesystem_full_in_7d = {
-    condition = ''node_filesystem_free_bytes{${filesystemFilter}} ''
-      + ''and predict_linear(node_filesystem_free_bytes{${filesystemFilter}}[2d], 7*24*3600) <= 0'';
+    condition = excl: ''node_filesystem_free_bytes{${filesystemFilter}${ensureComma excl}} ''
+      + ''and predict_linear(node_filesystem_free_bytes{${filesystemFilter}${ensureComma excl}}[2d], 7*24*3600) <= 0'';
     time = "1h";
     summary = "{{$labels.alias}}: Filesystem is running out of space in 7 days.";
     description = "{{$labels.alias}} device {{$labels.device}} on {{$labels.mountpoint}} is running out of space in approx. 7 days";
   };
   node_filesystem_full_in_30d = {
-    condition = ''node_filesystem_free_bytes{${filesystemFilter}} ''
-      + ''and predict_linear(node_filesystem_free_bytes{${filesystemFilter}}[30d], 30*24*3600) <= 0'';
+    condition = excl: ''node_filesystem_free_bytes{${filesystemFilter}${ensureComma excl}} ''
+      + ''and predict_linear(node_filesystem_free_bytes{${filesystemFilter}${ensureComma excl}}[30d], 30*24*3600) <= 0'';
     time = "1h";
     summary = "{{$labels.alias}}: Filesystem is running out of space in 30 days.";
     description = "{{$labels.alias}} device {{$labels.device}} on {{$labels.mountpoint}} is running out of space in approx. 30 days";
   };
   node_inodes_full_in_7d = {
-    condition = ''node_filesystem_files_free{${filesystemFilter}} ''
-      + ''and predict_linear(node_filesystem_files_free{${filesystemFilter}}[2d], 7*24*3600) < 0'';
+    condition = excl: ''node_filesystem_files_free{${filesystemFilter}${ensureComma excl}} ''
+      + ''and predict_linear(node_filesystem_files_free{${filesystemFilter}${ensureComma excl}}[2d], 7*24*3600) < 0'';
     time = "1h";
     summary = "{{$labels.alias}}: Filesystem is running out of inodes in 7 days.";
     description = "{{$labels.alias}} device {{$labels.device}} on {{$labels.mountpoint}} is running out of inodes in approx. 7 days";
   };
   node_inodes_full_in_30d = {
-    condition = ''node_filesystem_files_free{${filesystemFilter}} ''
-      + ''and predict_linear(node_filesystem_files_free{${filesystemFilter}}[30d], 30*24*3600) < 0'';
+    condition = excl: ''node_filesystem_files_free{${filesystemFilter}${ensureComma excl}} ''
+      + ''and predict_linear(node_filesystem_files_free{${filesystemFilter}${ensureComma excl}}[30d], 30*24*3600) < 0'';
     time = "1h";
     summary = "{{$labels.alias}}: Filesystem is running out of inodes in 30 days.";
     description = "{{$labels.alias}} device {{$labels.device}} on {{$labels.mountpoint}} is running out of inodes in approx. 30 days";
   };
   node_filedescriptors_full_in_3h = {
-    condition = ''node_filefd_allocated ''
-      + ''and predict_linear(node_filefd_allocated[3h], 3*3600) >= node_filefd_maximum'';
+    condition = excl: ''node_filefd_allocated{${excl}} ''
+      + ''and predict_linear(node_filefd_allocated{${excl}}[3h], 3*3600) >= node_filefd_maximum{${excl}}'';
     time = "20m";
     summary = "{{$labels.alias}} is running out of available file descriptors in 3 hours.";
     description = "{{$labels.alias}} is running out of available file descriptors in approx. 3 hours";
   };
   node_filedescriptors_full_in_7d = {
-    condition = ''node_filefd_allocated ''
-      + ''and predict_linear(node_filefd_allocated[7d], 7*24*3600) >= node_filefd_maximum'';
+    condition = excl: ''node_filefd_allocated{${excl}} ''
+      + ''and predict_linear(node_filefd_allocated{${excl}}[7d], 7*24*3600) >= node_filefd_maximum{${excl}}'';
     time = "1h";
     summary = "{{$labels.alias}} is running out of available file descriptors in 7 days.";
     description = "{{$labels.alias}} is running out of available file descriptors in approx. 7 days";
   };
   node_load15 = {
-    condition = ''node_load15 / on(alias) count(node_cpu_seconds_total{mode="system"}) by (alias) >= 1.0'';
+    condition = excl: ''node_load15{${excl}} / on(alias) count(node_cpu_seconds_total{mode="system"${ensureComma excl}}) by (alias) >= 1.0'';
     time = "10m";
     summary = "{{$labels.alias}}: Running on high load: {{$value}}";
     description = "{{$labels.alias}} is running with load15 > 1 for at least 5 minutes: {{$value}}";
   };
   node_ram_using_90percent_non_zfs_nodes = {
-    condition =  "node_memory_MemAvailable_bytes < node_memory_MemTotal_bytes * 0.1 unless node_zfs_arc_size";
+    condition =  excl: "node_memory_MemAvailable_bytes{${excl}} < node_memory_MemTotal_bytes{${excl}} * 0.1 unless node_zfs_arc_size{${excl}}";
     time = "1h";
     summary = "{{$labels.alias}}: Using lots of RAM.";
     description = "{{$labels.alias}} is using at least 90% of its RAM for at least 1 hour.";
   };
   node_ram_using_90percent_zfs_nodes = {
-    condition =  "node_memory_MemAvailable_bytes + node_zfs_arc_size - node_zfs_arc_c_min < node_memory_MemTotal_bytes * 0.1";
+    condition =  excl: "node_memory_MemAvailable_bytes{${excl}} + node_zfs_arc_size{${excl}} - node_zfs_arc_c_min{${excl}} < node_memory_MemTotal_bytes{${excl}} * 0.1";
     time = "1h";
     summary = "{{$labels.alias}}: Using lots of RAM.";
     description = "{{$labels.alias}} is using at least 90% of its RAM for at least 1 hour.";
   };
   node_swap_using_30percent = {
-    condition = "node_memory_SwapTotal_bytes - (node_memory_SwapFree_bytes + node_memory_SwapCached_bytes) > node_memory_SwapTotal_bytes * 0.3";
+    condition = excl: "node_memory_SwapTotal_bytes{${excl}} - (node_memory_SwapFree_bytes{${excl}} + node_memory_SwapCached_bytes{${excl}}) > node_memory_SwapTotal_bytes{${excl}} * 0.3";
     time = "30m";
     summary = "{{$labels.alias}}: Using more than 30% of its swap.";
     description = "{{$labels.alias}} is using 30% of its swap space for at least 30 minutes.";
   };
   node_oom = {
-    condition = "rate(node_vmstat_oom_kill[1h]) > 0";
+    condition = excl: "rate(node_vmstat_oom_kill{${excl}}[1h]) > 0";
     summary = "{{$labels.alias}}: OOM killer fired";
   };
   node_visible_confluence_space = {
-    condition = "node_visible_confluence_space != 0";
+    condition = excl: "node_visible_confluence_space{${excl}} != 0";
     summary = "crowd prometheus cann see the {{$labels.space_name}} confluence space!";
     description = "crowd user `prometheus` can see the `{{$labels.space_name}}` confluence space.";
   };
   node_visible_jira_project = {
-    condition = "node_visible_jira_project != 0";
+    condition = excl: "node_visible_jira_project{${excl}} != 0";
     summary = "crowd user `prometheus` can see the `{{$labels.project_name}}` jira project.";
     description = "crowd user `prometheus` can see the `{{$labels.project_name}}` jira project.";
   };
   node_zfs_errors = {
-    condition = "node_zfs_arc_l2_writes_error + node_zfs_arc_l2_io_error + node_zfs_arc_l2_writes_error > 0";
+    condition = excl: "node_zfs_arc_l2_writes_error{${excl}} + node_zfs_arc_l2_io_error{${excl}} + node_zfs_arc_l2_writes_error{${excl}} > 0";
     summary = "{{$labels.alias}}: ZFS IO errors: {{$value}}";
     description = "{{$labels.alias}} reports: {{$value}} ZFS IO errors. Drive(s) are failing.";
   };
   node_hwmon_temp = {
-    condition = "node_hwmon_temp_celsius > node_hwmon_temp_crit_celsius-5";
+    condition = excl: "node_hwmon_temp_celsius{${excl}} > node_hwmon_temp_crit_celsius{${excl}}-5";
     time = "5m";
     summary = "{{$labels.alias}}: Sensor {{$labels.sensor}}/{{$labels.chip}} temp is high: {{$value}} ";
     description = "{{$labels.alias}} reports hwmon sensor {{$labels.sensor}}/{{$labels.chip}} temperature value is nearly critical: {{$value}}";
   };
   node_conntrack_limit = {
-    condition  = "node_nf_conntrack_entries_limit - node_nf_conntrack_entries < 1000";
+    condition  = excl: "node_nf_conntrack_entries_limit{${excl}} - node_nf_conntrack_entries{${excl}} < 1000";
     time = "5m";
     summary = "{{$labels.alias}}: Number of tracked connections high";
     description = "{{$labels.alias}} has only {{$value}} free slots for connection tracking available.";
   };
   node_reboot = {
-    condition = "time() - node_boot_time_seconds < 300";
+    condition = excl: "time() - node_boot_time_seconds{${excl}} < 300";
     summary = "{{$labels.alias}}: Reboot";
     description = "{{$labels.alias}} just rebooted.";
   };
   node_uptime = {
-    condition = "time() - node_boot_time_seconds > 2592000";
+    condition = excl: "time() - node_boot_time_seconds{${excl}} > 2592000";
     page = false;
     summary = "{{$labels.alias}}: Uptime monster";
     description = "{{$labels.alias}} has been up for more than 30 days.";
   };
   blackbox_down = {
-    condition = ''min(up{job=~"blackbox.+"}) by (source, job, instance) == 0'';
+    condition = excl: ''min(up{job=~"blackbox.+"${ensureComma excl}}) by (source, job, instance) == 0'';
     time = "3m";
     summary = "{{$labels.instance}}: {{$labels.job}} blackbox exporter from {{$labels.source}} is down.";
   };
   blackbox_probe = {
-    condition = "probe_success == 0";
+    condition = excl: "probe_success{${excl}} == 0";
     page = false;
     summary = "{{$labels.instance}}: {{$labels.job}} probe from {{$labels.source}} has failed!";
   };
   blackbox_probe_high_latency = {
-    condition = "probe_duration_seconds > 2 and probe_success == 1";
+    condition = excl: "probe_duration_seconds{${excl}} > 2 and probe_success{${excl}} == 1";
     summary = "{{$labels.instance}}: {{$labels.job}} probe from {{$labels.source}} takes too long!";
     description = "{{$labels.instance}}: {{$labels.job}} probe from {{$labels.source}} is encountering high latency!";
   };
   blackbox_probe_cert_expiry = {
-    condition = "probe_ssl_earliest_cert_expiry < 7*24*3600";
+    condition = excl: "probe_ssl_earliest_cert_expiry{${excl}} < 7*24*3600";
     summary = "{{$labels.instance}}: TLS certificate from {{$labels.source}} is about to expire.";
     description = "{{$labels.instance}}: The TLS certificate from {{$labels.source}} will expire in less than 7 days: {{$value}}s";
   };
   unifi_devices_adopted_changed = {
-    condition = ''sum(abs(delta(unifipoller_site_adopted{status="ok"}[1h]))) >= 1'';
+    condition = excl: ''sum(abs(delta(unifipoller_site_adopted{status="ok"${ensureComma excl}}[1h]))) >= 1'';
     summary = "Unifi: number of adopted devices has changed: {{$value}}";
   };
   unifi_device_excessive_memory_usage = {
-    condition = ''unifipoller_device_memory_utilization_ratio >= 0.9'';
+    condition = excl: ''unifipoller_device_memory_utilization_ratio{${excl}} >= 0.9'';
     summary = "Unifi: memory utilisation exceeds 90% on device {{$labels.name}}";
   };
   unifi_device_reboot = {
-    condition = ''unifipoller_device_uptime_seconds{site_name!~"down.+"} > 0 and unifipoller_device_uptime_seconds{site_name!~"down.+"} < 300'';
+    condition = excl: ''unifipoller_device_uptime_seconds{site_name!~"down.+"${ensureComma excl}} > 0 and unifipoller_device_uptime_seconds{site_name!~"down.+"} < 300'';
     summary = "Unifi: device {{$labels.name}} reboot";
     description = "Unifi: device {{$labels.name}} just rebooted";
   };
   unifi_device_down = {
-    condition = ''unifipoller_site_adopted{status="error",site_name!~"down.+"} >= 1'';
+    condition = excl: ''unifipoller_site_adopted{status="error",site_name!~"down.+"${ensureComma excl}} >= 1'';
     summary = "Unifi: {{$value}} device(s) down in {{$labels.site_name}}";
   };
   mail_down = {
-    condition = ''up{job="mail"} == 0'';
+    condition = excl: ''up{job="mail"${ensureComma excl}} == 0'';
     summary = "{{$labels.alias}}: Mail exporter is down.";
     description = "Mail exporter on {{$labels.alias}} hasn't been responding more than 2 minutes.";
   };
   mail_delivery_unsuccessful = {
-    condition = "mail_deliver_success == 0";
+    condition = excl: "mail_deliver_success{${excl}} == 0";
     summary = "{{$labels.alias}}: Mail delivery unsuccessful";
   };
   mail_delivery_late = {
-    condition = "increase(mail_late_mails_total[1h]) >= 1";
+    condition = excl: "increase(mail_late_mails_total{${excl}}[1h]) >= 1";
     summary = "{{$labels.alias}}: Mail delivery late";
   };
   mail_send_fails = {
-    condition = "increase(mail_send_fails_total[1h]) >= 1";
+    condition = excl: "increase(mail_send_fails_total{${excl}}[1h]) >= 1";
     summary = "{{$labels.alias}}: Mail send failed";
   };
   postfix_queue_deferred_messages = {
-    condition = ''postfix_showq_message_size_bytes_count{queue="deferred"} > 1'';
+    condition = excl: ''postfix_showq_message_size_bytes_count{queue="deferred"${ensureComma excl}} > 1'';
     summary = "{{$labels.alias}}: postfix has deferred messages in queue";
   };
   alerts_silences_changed = {
-    condition = ''abs(delta(alertmanager_silences{state="active"}[1h])) >= 1'';
+    condition = excl: ''abs(delta(alertmanager_silences{state="active"${ensureComma excl}}[1h])) >= 1'';
     summary = "alertmanager: number of active silences has changed: {{$value}}";
   };
   smart_critical_attributes = {
-    condition = ''smartmon_attr_raw_value{name=~".*_retry_count|reallocated_.*|current_pending_sector"} != 0'';
+    condition = excl: ''smartmon_attr_raw_value{name=~".*_retry_count|reallocated_.*|current_pending_sector"${ensureComma excl}} != 0'';
     summary = "{{$labels.alias}}: {{$labels.disk}} is experiencing sector errors";
     description = "{{$labels.alias}}: {{$labels.name}} on {{$labels.disk}} is {{$value}}";
   };

--- a/modules/monitoring/alerting.nix
+++ b/modules/monitoring/alerting.nix
@@ -2,12 +2,12 @@
 with lib;
 let
   cfg = config.mayflower.monitoring.server;
-  alertRuleModule = types.submodule ({ config, ... }: {
+  alertRuleModule = types.submodule ({ name, config, ... }: {
     options = {
       enable = mkEnableOption "this alerting rule" // { default = true; };
       page = mkEnableOption "paging for this alert" // { default = true; };
       condition = mkOption {
-        type = types.str;
+        type = types.functionTo types.str;
         description = "Alert condition";
       };
       summary = mkOption {
@@ -24,11 +24,109 @@ let
         description = "Duration for which the condition must hold for the alert to fire";
         default = "2m";
       };
+      renderedCondition = mkOption {
+        internal = true;
+        readOnly = true;
+        type = types.str;
+        description = "condition, but with all exclusions added";
+      };
     };
-    config.description = lib.mkDefault config.summary;
+    config = {
+      description = lib.mkDefault config.summary;
+      renderedCondition = config.condition (renderExclusions (exclusionsByHosts.${name} or []));
+    };
   });
 
   enabledRules = mapAttrs (n: v: removeAttrs v ["enable"]) (filterAttrs (n: v: v.enable) cfg.alertRules);
+
+  renderExclusions = concatMapStringsSep
+    ","
+    (host: "instance!~'${host}(:[0-9]+)?'");
+
+  /*
+   * List of excluded rules by host names.
+   * Example:
+   * {
+   *   "node_down"     = [ "example.org" "container.example.org" "router.lan" ];
+   *   "node_deployed" = [ "example.org" ];
+   * }
+   */
+  exclusionsByHosts = foldl
+    (excludedRules: currentHost:
+      let
+        inherit (currentHost.mayflower.monitoring) disabledAlertRules;
+
+        appendChanges' = exclusions: rule: hostNameOrNames: (exclusions.${rule} or []) ++ (toList hostNameOrNames);
+        appendChanges = appendChanges' excludedRules;
+
+        /*
+         * Creates a list of changes to append to the exclusion list.
+         *
+         * Example:
+         * mkDelta [ "node_down" "node_deployed" ] "example.org"
+         * ⇒
+         * {
+         *   "node_down" = "example.org";
+         *   "node_deployed" = "example.org";
+         * }
+         */
+        mkDelta = disabledAlertRules: hostName:
+          listToAttrs
+            (map (rule: nameValuePair rule hostName) disabledAlertRules);
+
+        /*
+         * Attrset of excluded rules from a node inside the deployment (later added via `appendChanges`)
+         * to the final result.
+         *
+         * Example:
+         * Given a node with
+         * {
+         *   deployment.targetHost = "example.org";
+         *   mayflower.monitoring.disabledAlertRules = [ "node_up" ];
+         * }
+         * ⇒
+         * {
+         *   "node_deployed" = "node_up";
+         * }
+         */
+        deltaHost = mkDelta disabledAlertRules currentHost.deployment.targetHost;
+
+        /*
+         * Attrset of excluded rules for containers on a given host.
+         *
+         * Example:
+         * Given a node with:
+         * {
+         *   mayflower.monitoring.containerDomains."br-lan" = "lan.example.org";
+         *   containers.foo = {
+         *     hostBridge = "br-lan";
+         *     config = {
+         *       networking.hostName = "container";
+         *       mayflower.monitoring.disabledAlertRules = [ "node_up" ];
+         *     };
+         *   };
+         * }
+         * ⇒
+         * {
+         *   "node_up" = [ "foo.lan.example.org" ];
+         * }
+         */
+        deltaContainers = foldl
+          (exclusions: container:
+            let
+              inherit (container.config.mayflower.monitoring) disabledAlertRules;
+              hostName = container.config.networking.hostName
+                + "."
+                + currentHost.mayflower.monitoring.containerDomains.${container.hostBridge};
+            in exclusions // (mapAttrs (appendChanges' exclusions) (mkDelta disabledAlertRules hostName)))
+          {}
+          (attrValues currentHost.containers);
+      in
+      excludedRules
+      // (mapAttrs appendChanges deltaHost)
+      // (mapAttrs appendChanges deltaContainers))
+    {}
+    (attrValues config.mayflower.machines);
 in {
   options.mayflower.monitoring.server = {
     alertRules = mkOption {
@@ -40,6 +138,14 @@ in {
       default = ''fstype!="ramfs",device!="rpc_pipefs",device!="lxcfs",device!="nsfs",device!="borgfs"'';
     };
   };
+  options.mayflower.monitoring.disabledAlertRules = mkOption {
+    type = types.listOf types.str;
+    default = [];
+    description = ''
+      Can be set on any node in the deployment. Ensures that
+      each alert rule inside this list doesn't fire for that node.
+    '';
+  };
   config = {
     mayflower.monitoring.server.alertRules = import ./alert-rules.nix { inherit (cfg) filesystemFilter; };
     services.prometheus.ruleFiles = singleton (pkgs.writeText "prometheus-rules.yml" (builtins.toJSON {
@@ -47,7 +153,7 @@ in {
         name = "mf-alerting-rules";
         rules = flip mapAttrsToList enabledRules (name: opts: {
           alert = name;
-          expr = opts.condition;
+          expr = opts.renderedCondition;
           for = opts.time;
           labels = optionalAttrs opts.page { severity = "page"; };
           annotations = {


### PR DESCRIPTION
This is useful for e.g. our Hydra where we don't want bogus `node_filesystem_full_in_7d` alerts whenever we build our nixpkgs fork after pulling in a mass-rebuild.

Since we exclude hosts directly in the alert-condition and it doesn't make much sense to hard-code hostnames from our deployment here since this is intended to be reusable, I decided to implement a more generic version.

You can basically do something like this now:

    # nodes/example.nix
    {
      deployment.targetHost = "example.org";
      mayflower.monitoring.disabledAlertRules = [ "node_deployed" ];
    }

Then, `example.org` will be ignored within the `node_deployed` rule by adding a `instance!~'example.org(:[0-9]+)?'`. The regex at the end is necessary because we have both metrics where `instance` is a hostname with port (of the prometheus exporter where the metric stems from) and metrics where `instance` is only a hostname (e.g. for blackbox scrapes).