### PR TITLE
simplesamlphp: 1.19.6 -> 1.19.8, module-privacyidea: 2.1.3 -> 3.0.0

### DIFF
--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -331,7 +331,7 @@ in
             'privacyideaServerURL' => 'https://privacyidea.example.org/',
             // sends the password/pin on the first step, so you don't have to re-enter
             // it when doing any kind of challenge (e.g. U2F) as second factor.
-            'doSendPassword' => 'true',
+            'authenticationFlow' => 'sendPassword',
             'sslVerifyPeer' => true,
             'realm' => "",
             'attributemap' => [

--- a/pkgs/simplesamlphp/default.nix
+++ b/pkgs/simplesamlphp/default.nix
@@ -11,11 +11,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "simplesamlphp-${version}";
-  version = "1.19.6";
+  version = "1.19.8";
 
   src = fetchurl {
     url = "https://github.com/simplesamlphp/simplesamlphp/releases/download/v${version}/simplesamlphp-${version}.tar.gz";
-    sha256 = "sha256-g0u0qJ1j10mOd8zrSeAbkZ0cCmo9OKmS+QWBDa1CS3w=";
+    sha256 = "sha256-qQQV+ECDB1pmWXeG2fR1d+reR25tNk7DNIXsXNyMYRo=";
   };
 
   buildPhase = ''

--- a/pkgs/simplesamlphp/module-privacyidea.nix
+++ b/pkgs/simplesamlphp/module-privacyidea.nix
@@ -1,21 +1,14 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch }:
+{ stdenv, lib, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   name = "simplesamlphp-module-privacyidea-${version}";
-  version = "2.1.3";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "privacyidea";
     repo = "simplesamlphp-module-privacyidea";
     rev = "v${version}";
-    sha256 = "sha256-1kg1R7BOKDZWu/Cbf3QunzHwpby+nwdbm8aV7ihv2jI=";
+    sha256 = "sha256-5KHM0k7gVGaeMy15mw1oDnowGTdqKPcyNaiDDiDbpmg=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/privacyidea/simplesamlphp-module-privacyidea/commit/f54e3e2bbd7dcb4d0edf91c0576b11e40c569e94.patch";
-      sha256 = "sha256-t6kvcF53aQcbxmqymAIwd73vaObm5LOJCe8O8FZ3n6s=";
-    })
-  ];
 
   installPhase = ''
     cp -va . $out


### PR DESCRIPTION
Support for simplesamlphp-2.0 is not ready yet, so we stick with 1.19. Updating is still relevant though because 1.19.8 is marked as security release[1] as it updates the Symfony http cache dependency to fix CVE-2022-24894. Additionally, 1.19.7 also contains a bunch of bugfixes.

While at it, I decided to update the privacyidea integration to the latest version available (3.0). This contains a few config changes (as outlined in the option's example of the NixOS module). Already tested the change on my private infrastructure and the auth flows for Nextcloud and Meshcentral work fine there.

[1] https://github.com/simplesamlphp/simplesamlphp/releases/tag/v1.19.8