### PR TITLE
modules/simplesamlphp: use php 8.1

### DIFF
--- a/modules/simplesamlphp.nix
+++ b/modules/simplesamlphp.nix
@@ -449,7 +449,7 @@ in
     services.phpfpm.pools.simplesamlphp = {
         user = "simplesamlphp";
         group = "nginx";
-        phpPackage = pkgs.php80;
+        phpPackage = pkgs.php81;
         settings = {
           "listen.owner" = "nginx";
           "listen.group" = "nginx";


### PR DESCRIPTION
PHP 8.0 is marked as insecure because it depends on OpenSSL 1.1.1 which gets EOLed in September 2023, i.e. the lifetime of 23.05.

-----

Just deployed this on my personal setup and authentication (tested YubiKey OTP, WebAuthn with  YubiKey, SPass) works fine.