### PR TITLE
modules/matrix: fix federation not using IPv6 by default

### DIFF
--- a/modules/matrix.nix
+++ b/modules/matrix.nix
@@ -282,7 +282,7 @@ in
           # See https://github.com/matrix-org/synapse#reverse-proxying-the-federation-port
           listeners = [{
             port = 8448;
-            bind_addresses = [ "" ];
+            bind_addresses = [ "::" ];
             type = "http";
             tls = true;
             x_forwarded = false;


### PR DESCRIPTION
Wasn't a noticeable issue so far and the [manual](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html?highlight=bind_add#listeners) is not making this very obvious but now the service listens on both ipv4 and ipv6